### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dlib==19.17.0
-matplotlib==3.1.1
+matplotlib==3.1.3
 numpy==1.16.4


### PR DESCRIPTION
Update matplotlib version.
Because Windows10 tries to build old matplotlib from source, but new version has .whl file.