### PR TITLE
Only add image to warped/incremental if saving gif

### DIFF
--- a/facer/facer.py
+++ b/facer/facer.py
@@ -238,7 +238,8 @@ def create_average_face(faces,
                     tin.append(pIn)
                     tout.append(pOut)
                 img = warpTriangle(imagesNorm[i], img, tin, tout)
-            incremental.append((output + img) / (i + 1))
+            if return_intermediates:
+                incremental.append((output + img) / (i + 1))
 
 
             # Add image intensities for averaging
@@ -247,7 +248,8 @@ def create_average_face(faces,
         # Divide by num_images to get average
         output = output / num_images
 
-        warped.append(img_affine)
+        if return_intermediates:
+            warped.append(img_affine)
     incremental = incremental[-num_images:]
     print('Done.')
 


### PR DESCRIPTION
I tried running Facer on ~600 images this afternoon but my process kept getting OOM killed after processing about 50 images on my laptop with 16 gb of ram. After digging into the code, I found that the library was storing intermediate results from each face in memory in order to generate animated GIFs of the averaging process (which is super cool, but also not what I wanted).

This PR makes some small changes to only save those intermediate results when `return_intermediates` is true. Memory consumption stayed relatively manageable for me after this, and I was successfully able to average all 600 faces without crashing.