### PR TITLE
Add option to set predictor path as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ The face landmark detection relies on a pre-trained model that must be downloade
 wget http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
 ```
 
-Unzip the compressed file after it finishes downloading and move it into the `./Facer/model` directory.
+Unzip the compressed file after it finishes downloading and move it into a `./model` directory.
+
+If you store the downloaded file somewhere other than `./model` (or if you use an entirely different model name), you can set a custom model path as an environment variable:
+
+```bash
+export FACER_PREDICTOR_PATH="./custom/path/to/your/model.dat"
+```
 
 ## Usage
 

--- a/facer/facer.py
+++ b/facer/facer.py
@@ -40,8 +40,14 @@ def load_rgb_image(filename: str) -> NumPyNumericArray:
     return dlib.load_rgb_image(filename)  # type: ignore[no-any-return]
 
 
+# Determine the path to the predictor
+# Set a non-default path by setting the environment variable FACER_PREDICTOR_PATH
+if (PREDICTOR_PATH := os.environ.get("FACER_PREDICTOR_PATH")) is None:
+    PREDICTOR_PATH = "./model/shape_predictor_68_face_landmarks.dat"
+if not os.path.exists(PREDICTOR_PATH):
+    raise FileNotFoundError(f"Couldn't find the predictor at: {PREDICTOR_PATH}")
+
 # Load the face detector and landmark predictor
-PREDICTOR_PATH = "./model/shape_predictor_68_face_landmarks.dat"
 detector = load_face_detector()
 predictor = load_landmark_predictor(PREDICTOR_PATH)
 print("Done, models loaded.")


### PR DESCRIPTION
This PR adds an option to specify a custom predictor path via an environment variable.

Resolves #9.